### PR TITLE
Define DPType locally to remove broken tuya_device_handlers dependency

### DIFF
--- a/custom_components/tuya_ble/const.py
+++ b/custom_components/tuya_ble/const.py
@@ -62,6 +62,18 @@ FINGERBOT_BUTTON_EVENT: Final = "fingerbot_button_pressed"
 
 CONNECTED_DP_ID = -2
 
+
+class DPType(StrEnum):
+    """Data point types."""
+
+    BOOLEAN = "Boolean"
+    ENUM = "Enum"
+    INTEGER = "Integer"
+    JSON = "Json"
+    RAW = "Raw"
+    STRING = "String"
+
+
 @dataclass
 class Country:
     """Describe a supported country."""

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -24,9 +24,6 @@ from homeassistant.components.tuya.const import (
     DPCode,
 )
 
-from tuya_device_handlers.const import (
-    DPType,
-)
 
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 from .tuya_ble import (
@@ -40,6 +37,7 @@ from .cloud import HASSTuyaBLEDeviceManager
 from .const import (
     DEVICE_DEF_MANUFACTURER,
     DOMAIN,
+    DPType,
     FINGERBOT_BUTTON_EVENT,
     SET_DISCONNECTED_DELAY,
 )

--- a/custom_components/tuya_ble/light.py
+++ b/custom_components/tuya_ble/light.py
@@ -16,9 +16,6 @@ from homeassistant.components.tuya.const import (
     WorkMode,
 )
 
-from tuya_device_handlers.const import (
-    DPType,
-)
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -36,7 +33,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.const import EntityCategory
 
-from .const import DOMAIN
+from .const import DOMAIN, DPType
 from .base import IntegerTypeData
 from .util import remap_value
 from .devices import TuyaBLEData, TuyaBLEEntity, TuyaBLEProductInfo

--- a/custom_components/tuya_ble/tuya_ble/tuya_ble.py
+++ b/custom_components/tuya_ble/tuya_ble/tuya_ble.py
@@ -29,7 +29,7 @@ from homeassistant.components.tuya.const import (
     DPCode,
 )
 
-from tuya_device_handlers.const import (
+from ..const import (
     DPType,
 )
 


### PR DESCRIPTION
Home Assistant 2026.3 reorganised its bundled Tuya integration internals. As part of that change, `DPType` — an enum describing Tuya data-point value types (`Boolean`, `Enum`, `Integer`, etc.) — was removed from `homeassistant.components.tuya.const`.

A prior fix commit (`fc1080b`) handled this by importing `DPType` from an external package called `tuya_device_handlers`:

```python
from tuya_device_handlers.const import (
    DPType,
)
```

However, `tuya_device_handlers` is not declared as a dependency in `manifest.json` and is not shipped with Home Assistant, so the integration failed to load entirely with:

```
ModuleNotFoundError: No module named 'tuya_device_handlers'
```

## What was changed

`DPType` is a small, stable enum with six well-known values defined by the Tuya IoT platform. Rather than depend on an undeclared external package for it, the fix defines it directly inside the integration's own `const.py`.

This approach and the `DPType` definition were adapted from [@airy10](https://github.com/airy10)'s fork [airy10/ha_tuya_ble](https://github.com/airy10/ha_tuya_ble), specifically commit [`e7b1c6f`](https://github.com/airy10/ha_tuya_ble/commit/e7b1c6f) ("Remove dependency on bundled Tuya component"). Both repositories are MIT licensed (Copyright © 2023 PlusPlus-ua).

| File | Change |
|---|---|
| `custom_components/tuya_ble/const.py` | Added `DPType(StrEnum)` class definition |
| `custom_components/tuya_ble/tuya_ble/tuya_ble.py` | Replaced `from tuya_device_handlers.const import DPType` → `from ..const import DPType` |
| `custom_components/tuya_ble/light.py` | Replaced `from tuya_device_handlers.const import DPType` → added `DPType` to existing `from .const import` |
| `custom_components/tuya_ble/devices.py` | Replaced `from tuya_device_handlers.const import DPType` → added `DPType` to existing `from .const import` |
