### PR TITLE
Add CBF02V2 Finger Robot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ _Merged several changes by @airy10 and @patriot1889, including light support, fo
   + Fingerbot Plus (product_ids 'blliqpsj', 'ndvkgsrm', 'yiihr7zh', 'neq16kgd'), almost same as original, has sensor button for manual control.
   + CubeTouch 1s (product_id '3yqdo5yt'), built-in battery with USB type C charging.
   + CubeTouch II (product_id 'xhf790if'), built-in battery with USB type C charging.
+  + Finger Robot CBF02V2 (product_id 'bo25vaxy'), low-voltage MCU Fingerbot with click, switch and toggle modes.
 
   All features available in Home Assistant, programming (series of actions) is implemented for Fingerbot Plus.
   For programming exposed entities 'Program' (switch), 'Repeat forever', 'Repeats count', 'Idle position' and 'Program' (text). Format of program text is: 'position[/time];...' where position is in percents, optional time is in seconds (zero if missing).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ _Merged several changes by @airy10 and @patriot1889, including light support, fo
   + Fingerbot Plus (product_ids 'blliqpsj', 'ndvkgsrm', 'yiihr7zh', 'neq16kgd'), almost same as original, has sensor button for manual control.
   + CubeTouch 1s (product_id '3yqdo5yt'), built-in battery with USB type C charging.
   + CubeTouch II (product_id 'xhf790if'), built-in battery with USB type C charging.
-  + Finger Robot CBF02V2 (product_id 'bo25vaxy'), low-voltage MCU Fingerbot with click, switch and toggle modes.
+  + Finger Robot CBF02V2 (product_id 'bo25vaxy'), low-voltage MCU Fingerbot with click and switch modes.
 
   All features available in Home Assistant, programming (series of actions) is implemented for Fingerbot Plus.
   For programming exposed entities 'Program' (switch), 'Repeat forever', 'Repeats count', 'Idle position' and 'Program' (text). Format of program text is: 'position[/time];...' where position is in percents, optional time is in seconds (zero if missing).

--- a/custom_components/tuya_ble/button.py
+++ b/custom_components/tuya_ble/button.py
@@ -86,6 +86,12 @@ mapping: dict[str, TuyaBLECategoryButtonMapping] = {
                 ],
             ),
             **dict.fromkeys(
+                ["bo25vaxy"],  # CBF02V2 Fingerbot
+                [
+                    TuyaBLEFingerbotModeMapping(dp_id=1),
+                ],
+            ),
+            **dict.fromkeys(
                 [
                     "blliqpsj",
                     "ndvkgsrm",

--- a/custom_components/tuya_ble/devices.py
+++ b/custom_components/tuya_ble/devices.py
@@ -376,6 +376,20 @@ devices_database: dict[str, TuyaBLECategoryInfo] = {
                 ),
             ),
             **dict.fromkeys(
+                ["bo25vaxy"],  # CBF02V2 Fingerbot
+                TuyaBLEProductInfo(
+                    name="Finger Robot CBF02V2",
+                    fingerbot=TuyaBLEFingerbotInfo(
+                        switch=1,
+                        mode=2,
+                        up_position=4,
+                        down_position=5,
+                        hold_time=3,
+                        reverse_positions=0,
+                    ),
+                ),
+            ),
+            **dict.fromkeys(
                 ["blliqpsj", "ndvkgsrm", "yiihr7zh", "neq16kgd"],  # device product_ids
                 TuyaBLEProductInfo(
                     name="Fingerbot Plus",

--- a/custom_components/tuya_ble/number.py
+++ b/custom_components/tuya_ble/number.py
@@ -268,6 +268,33 @@ mapping: dict[str, TuyaBLECategoryNumberMapping] = {
                 ],
             ),
             **dict.fromkeys(
+                ["bo25vaxy"],  # CBF02V2 Fingerbot
+                [
+                    TuyaBLENumberMapping(
+                        dp_id=3,
+                        description=TuyaBLEHoldTimeDescription(
+                            native_min_value=0.3,
+                            native_step=0.1,
+                        ),
+                        coefficient=10.0,
+                        is_available=is_fingerbot_in_push_mode,
+                    ),
+                    TuyaBLENumberMapping(
+                        dp_id=4,
+                        description=TuyaBLEUpPositionDescription(
+                            native_max_value=30,
+                        ),
+                    ),
+                    TuyaBLENumberMapping(
+                        dp_id=5,
+                        description=TuyaBLEDownPositionDescription(
+                            native_max_value=30,
+                            native_min_value=0,
+                        ),
+                    ),
+                ],
+            ),
+            **dict.fromkeys(
                 [
                     "blliqpsj",
                     "ndvkgsrm",

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -143,7 +143,6 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                             options=[
                                 "click",
                                 "switch",
-                                "toggle",
                             ],
                         ),
                     ),

--- a/custom_components/tuya_ble/select.py
+++ b/custom_components/tuya_ble/select.py
@@ -133,6 +133,23 @@ mapping: dict[str, TuyaBLECategorySelectMapping] = {
                 ],
             ),
             **dict.fromkeys(
+                ["bo25vaxy"],  # CBF02V2 Fingerbot
+                [
+                    TuyaBLESelectMapping(
+                        dp_id=2,
+                        description=SelectEntityDescription(
+                            key="fingerbot_mode",
+                            entity_category=EntityCategory.CONFIG,
+                            options=[
+                                "click",
+                                "switch",
+                                "toggle",
+                            ],
+                        ),
+                    ),
+                ],
+            ),
+            **dict.fromkeys(
                 [
                     "blliqpsj",
                     "ndvkgsrm",

--- a/custom_components/tuya_ble/sensor.py
+++ b/custom_components/tuya_ble/sensor.py
@@ -202,6 +202,31 @@ mapping: dict[str, TuyaBLECategorySensorMapping] = {
                 ],
             ),
             **dict.fromkeys(
+                ["bo25vaxy"],  # CBF02V2 Fingerbot
+                [
+                    TuyaBLESensorMapping(
+                        dp_id=7,
+                        description=SensorEntityDescription(
+                            key="battery_charging",
+                            device_class=SensorDeviceClass.ENUM,
+                            entity_category=EntityCategory.DIAGNOSTIC,
+                            options=[
+                                "none",
+                                "charging",
+                                "charge_done",
+                            ],
+                        ),
+                        icons=[
+                            "mdi:power-plug-off",
+                            "mdi:power-plug-battery",
+                            "mdi:battery-check",
+                        ],
+                        default_value="none",
+                    ),
+                    TuyaBLEBatteryMapping(dp_id=8),
+                ],
+            ),
+            **dict.fromkeys(
                 [
                     "blliqpsj",
                     "ndvkgsrm",

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -79,9 +79,11 @@
       "fingerbot_mode": {
         "name": "Mode",
         "state": {
+          "click": "Click",
           "program": "Program",
           "push": "Push",
-          "switch": "[%key:component::switch::entity_component::_::name%]"
+          "switch": "[%key:component::switch::entity_component::_::name%]",
+          "toggle": "Toggle"
         }
       },
       "temperature_unit": {

--- a/custom_components/tuya_ble/strings.json
+++ b/custom_components/tuya_ble/strings.json
@@ -82,8 +82,7 @@
           "click": "Click",
           "program": "Program",
           "push": "Push",
-          "switch": "[%key:component::switch::entity_component::_::name%]",
-          "toggle": "Toggle"
+          "switch": "[%key:component::switch::entity_component::_::name%]"
         }
       },
       "temperature_unit": {

--- a/custom_components/tuya_ble/switch.py
+++ b/custom_components/tuya_ble/switch.py
@@ -108,6 +108,27 @@ def set_fingerbot_program_repeat_forever(
             self._hass.create_task(datapoint.set_value(new_value))
 
 
+def get_inverted_switch(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo
+) -> bool | None:
+    datapoint = self._device.datapoints[self._mapping.dp_id]
+    if datapoint:
+        return not bool(datapoint.value)
+    return False
+
+
+def set_inverted_switch(
+    self: TuyaBLESwitch, product: TuyaBLEProductInfo, value: bool
+) -> None:
+    datapoint = self._device.datapoints.get_or_create(
+        self._mapping.dp_id,
+        TuyaBLEDataPointType.DT_BOOL,
+        not value,
+    )
+    if datapoint:
+        self._hass.create_task(datapoint.set_value(not value))
+
+
 @dataclass
 class TuyaBLEFingerbotSwitchMapping(TuyaBLESwitchMapping):
     description: SwitchEntityDescription = field(
@@ -224,6 +245,17 @@ mapping: dict[str, TuyaBLECategorySwitchMapping] = {
                 [
                     TuyaBLEFingerbotSwitchMapping(dp_id=1),
                     TuyaBLEReversePositionsMapping(dp_id=4),
+                ],
+            ),
+            **dict.fromkeys(
+                ["bo25vaxy"],  # CBF02V2 Fingerbot
+                [
+                    TuyaBLEFingerbotSwitchMapping(
+                        dp_id=1,
+                        is_available=None,
+                        getter=get_inverted_switch,
+                        setter=set_inverted_switch,
+                    ),
                 ],
             ),
             **dict.fromkeys(

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -109,9 +109,11 @@
       "fingerbot_mode": {
         "name": "Mode",
         "state": {
+          "click": "Click",
           "program": "Program",
           "push": "Push",
-          "switch": "Switch"
+          "switch": "Switch",
+          "toggle": "Toggle"
         }
       },
       "fingerbot_mode_1": {

--- a/custom_components/tuya_ble/translations/en.json
+++ b/custom_components/tuya_ble/translations/en.json
@@ -112,8 +112,7 @@
           "click": "Click",
           "program": "Program",
           "push": "Push",
-          "switch": "Switch",
-          "toggle": "Toggle"
+          "switch": "Switch"
         }
       },
       "fingerbot_mode_1": {


### PR DESCRIPTION
﻿## Summary
- add support for the Finger Robot CBF02V2 / Fingerbot product_id `bo25vaxy` in category `szjqr`
- map the confirmed DP layout: action/switch DP1, mode DP2, hold time DP3, arm up DP4, arm down DP5, charge status DP7, and battery DP8
- add mode labels for Click/Switch/Toggle and document the device in the README

## Device details
- Model: CBF02V2
- Product ID: `bo25vaxy`
- Category: `szjqr`
- Product name from Tuya: `手指机器人(低电压MCU)`

## Validation
- Tested on a physical CBF02V2 Finger Robot in Home Assistant
- Confirmed DP1 works as the press/action control
- Confirmed DP2 accepts Click, Switch, and Toggle modes despite the device-specific cloud spec only reporting Click while offline
- Confirmed switch state needed inversion for this model so HA on corresponds to the pressed/down position
- Tested DP101 `start` and DP102 `set_switch_state` separately, but intentionally did not include them because they behaved like calibration/internal controls rather than useful HA entities
- Ran `python -m json.tool` on `strings.json` and `translations/en.json`
- Ran `python -m py_compile` on the changed Python modules
